### PR TITLE
Init alpha prerelease

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@wlee221-changeset-poc/bar": "0.0.1",
+    "@wlee221-changeset-poc/core": "0.0.1",
+    "@wlee221-changeset-poc/foo": "0.0.1"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
This PR initiates the pre-release mode in changeset. Patched packages will be versioned and tagged with `alpha`.

Read more here: https://github.com/atlassian/changesets/blob/main/docs/prereleases.md.

