### PR TITLE
Changeset POC

### DIFF
--- a/.changeset/happy-onions-live.md
+++ b/.changeset/happy-onions-live.md
@@ -1,0 +1,5 @@
+---
+"@wlee221-changeset-poc/core": patch
+---
+
+Some PR change that I want to preview

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -18,11 +18,3 @@ jobs:
         run: |
           ls ${{ github.workspace }}
       - run: echo "🍏 This job's status is ${{ job.status }}."
-      - name: 'Comment on PR'
-        uses: actions/github-script@0.3.0
-        with:
-          github-token: ${{ secrets.GH_TOKEN }}
-          script: |
-            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const message = `📦 We publshed this PR to pr-${issue_number}!`
-            github.issues.createComment({ issue_number, owner, repo, body: message });

--- a/.github/workflows/github-actions-demo.yml
+++ b/.github/workflows/github-actions-demo.yml
@@ -18,3 +18,11 @@ jobs:
         run: |
           ls ${{ github.workspace }}
       - run: echo "🍏 This job's status is ${{ job.status }}."
+      - name: 'Comment on PR'
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            const message = `📦 We publshed this PR to pr-${issue_number}!`
+            github.issues.createComment({ issue_number, owner, repo, body: message });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -19,3 +19,5 @@ jobs:
       - name: Exit prerelease mode if on
         run: |
           [ -f .changeset/pre.json ] && yarn changeset pre exit
+      - name: Run changeset version
+        run: yarn changeset version

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,3 +1,4 @@
+name: PR Preview
 on:
   pull_request:
     types: [synchronize]

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: [synchronize]
 
-jobs: 
+jobs:
   Release-Snapshot:
     runs-on: ubuntu-latest
     steps:
@@ -16,3 +16,6 @@ jobs:
           version: 14.x
       - name: Install Dependencies
         run: yarn
+      - name: Exit prerelease mode if on
+        run: |
+          [ -f .changeset/pre.json ] && yarn changeset pre exit

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,5 +39,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const message = `📦 We publshed this PR to \`pr-${issue_number}!\``
+            const message = `📦 We publshed this PR to \`pr-${issue_number}\`!`;
             github.issues.createComment({ issue_number, owner, repo, body: message });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -21,5 +21,8 @@ jobs:
           [ -f .changeset/pre.json ] && yarn changeset pre exit
       - name: Run changeset version
         run: yarn changeset version --snapshot pr-${{ github.event.number }}
-      - name: Print package version changes
+      - name: Log package version changes
         run: cat ${{ github.workspace }}/packages/core/package.json
+      - name: Publish to pr-# tag
+        run: yarn changeset publish --tag pr-${{ github.event.number }}
+        

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -33,3 +33,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish to pr-# tag
         run: yarn changeset publish --tag pr-${{ github.event.number }}
+      - name: 'Comment on PR'
+        uses: actions/github-script@0.3.0
+        with:
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            const message = `📦 We publshed this PR to pr-${issue_number}!`
+            github.issues.createComment({ issue_number, owner, repo, body: message });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -25,4 +25,7 @@ jobs:
         run: cat ${{ github.workspace }}/packages/core/package.json
       - name: Publish to pr-# tag
         run: yarn changeset publish --tag pr-${{ github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -21,8 +21,8 @@ jobs:
           [ -f .changeset/pre.json ] && yarn changeset pre exit
       - name: Run changeset version
         run: yarn changeset version --snapshot pr-${{ github.event.number }}
-      - name: Log package version changes
-        run: cat ${{ github.workspace }}/packages/core/package.json
+      # - name: Log package version changes
+      #   run: cat ${{ github.workspace }}/packages/core/package.json
       - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,5 +39,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const message = `📦 We publshed this PR to \`pr-${issue_number}\`!`;
+            const message = `📦 We publshed this PR to \`pr-${issue_number}\` npm tag!`;
             github.issues.createComment({ issue_number, owner, repo, body: message });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -21,3 +21,5 @@ jobs:
           [ -f .changeset/pre.json ] && yarn changeset pre exit
       - name: Run changeset version
         run: yarn changeset version
+      - name: Find pr-#
+        run: echo "${{ github.event.number }}"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -7,7 +7,7 @@ jobs:
   Release-Snapshot:
     runs-on: ubuntu-latest
     steps:
-      - run: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Use Node.js 14.x

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -39,5 +39,5 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const message = `📦 We publshed this PR to pr-${issue_number}!`
+            const message = `📦 We publshed this PR to \`pr-${issue_number}!\``
             github.issues.createComment({ issue_number, owner, repo, body: message });

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -25,7 +25,11 @@ jobs:
         run: cat ${{ github.workspace }}/packages/core/package.json
       - name: Publish to pr-# tag
         run: yarn changeset publish --tag pr-${{ github.event.number }}
+      - name: Creating .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            email=wkl.hyo@gmail.com
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,17 @@
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs: 
+  Release-Snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - run: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          version: 14.x
+      - name: Install Dependencies
+        run: yarn

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -36,7 +36,7 @@ jobs:
       - name: 'Comment on PR'
         uses: actions/github-script@0.3.0
         with:
-          github-token: ${{ secrets.GH_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
             const message = `📦 We publshed this PR to pr-${issue_number}!`

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -23,8 +23,6 @@ jobs:
         run: yarn changeset version --snapshot pr-${{ github.event.number }}
       - name: Log package version changes
         run: cat ${{ github.workspace }}/packages/core/package.json
-      - name: Publish to pr-# tag
-        run: yarn changeset publish --tag pr-${{ github.event.number }}
       - name: Creating .npmrc
         run: |
           cat << EOF > "$HOME/.npmrc"
@@ -33,3 +31,5 @@ jobs:
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to pr-# tag
+        run: yarn changeset publish --tag pr-${{ github.event.number }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -20,6 +20,6 @@ jobs:
         run: |
           [ -f .changeset/pre.json ] && yarn changeset pre exit
       - name: Run changeset version
-        run: yarn changeset version
-      - name: Find pr-#
-        run: echo "${{ github.event.number }}"
+        run: yarn changeset version --snapshot pr-${{ github.event.number }}
+      - name: Print package version changes
+        run: cat ${{ github.workspace }}/packages/core/package.json


### PR DESCRIPTION
This PR is a POC for using `changesets` to publish pr-preview.

#### What changeset does well:
- We can choose the tag name of the snapshot.
- Don't need lerna.

#### Concerns / nuances:
- A `changeset` needs to be present to make a release. 
- Only the changed packages (determined from changesets in the pr) and their dependents will be tagged and released to pr-preview. 
- Does not comment on the PR about the release (contrary to auto: #3). But we can write a github actions to do so. I added a comment script for now.

---

#### Open Questions

Because we're trying to move away from lerna, I'm in favor of adopting #4 over #3. This leaves some open questions though:

- Security concerns. Should we publish previews from forks too?

If so, workflows triggered by PR commits will have write and secret access to the repository. Because this workflow can be triggered from an arbitrary commit, this is a big security compromise. We considered running the workflow to run only if a certain label is present. But even then, we can't be sure the subsequent commits after the label will be safe. 

We can publish pr-preview only once, right after the label was attached. Or we can block workflows from fork for a complete security measure.

- There needs to be a changeset to make a snapshot release. Is this an okay DX?

If there are no changesets in the PR, changeset won't bump the version and hence no preview release will be made. I think this is an acceptable behavior -- If a PR is complex enough to need a preview, it should have a changeset. But this slows down the DX a bit.

- How should the pr-preview be tagged on npm? 

Should it be unique for each PR (`@pr-3`) or be generic for all PRs? (`@canary`)? The latter is what auto does (#3).