### PR TITLE
Prevent non-zero exit code

### DIFF
--- a/.github/workflows/deprecate-preview.yml
+++ b/.github/workflows/deprecate-preview.yml
@@ -21,6 +21,10 @@ jobs:
         run: |
           for pkg in foo bar core
           do
-            version="$(npm view @wlee221-changeset-poc/$pkg dist-tags.pr-${{ github.event.number }})"
-            [ ! -z "$version" ] && npm deprecate "@wlee221-changeset-poc/$pkg@$version" "This preview has been deprecated."
+            version="$(npm view @wlee221-changeset-poc/$pkg dist-tags.pr-14)"
+            if [ ! -z "$version" ]; then
+              npm deprecate "@wlee221-changeset-poc/$pkg@$version" "This preview has been deprecated."
+            else
+              echo "No preview versions have been published for this PR."
+            fi
           done

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -41,8 +41,12 @@ jobs:
         run: |
           for pkg in foo bar core
           do
-            version="$(npm view @wlee221-changeset-poc/$pkg dist-tags.pr-${{ github.event.number }})"
-            [ ! -z "$version" ] && npm deprecate "@wlee221-changeset-poc/$pkg@$version" "This preview has been deprecated."
+            version="$(npm view @wlee221-changeset-poc/$pkg dist-tags.pr-14)"
+            if [ ! -z "$version" ]; then
+              npm deprecate "@wlee221-changeset-poc/$pkg@$version" "This preview has been deprecated."
+            else
+              echo "No preview versions have been published for this PR."
+            fi
           done
       - name: Publish to pr-# tag
         run: yarn changeset publish --tag pr-${{ github.event.number }}


### PR DESCRIPTION
Non-zero status code halts the ci. Using `if` syntax to avoid this.